### PR TITLE
Fix for W-18852147

### DIFF
--- a/src/remote-control/index.js
+++ b/src/remote-control/index.js
@@ -293,8 +293,8 @@ export function  initializeRemoteController(connector) {
                     }
                     break;
                     case Constants.SHARED_EVENT_TYPE.AFTER_CONVERSATION_WORK_STARTED:
-                    case Constants.SHARED_EVENT_TYPE.AFTER_CONVERSATION_WORK_ENDED:
-                        publishEvent({eventType: event.data.type, payload: new ACWInfo(event.data.acwInfo)});
+                    case Constants.VOICE_EVENT_TYPE.WRAP_UP_ENDED:
+                        publishEvent({eventType: event.data.type, payload: {callId: event.data.acwInfo.workItemId}});
                     break;
                     case Constants.CALL_UPDATED:
                         call = new PhoneCall({

--- a/src/remote-control/main.js
+++ b/src/remote-control/main.js
@@ -1438,7 +1438,7 @@ function startACW(){
 
 function endACW(){
     sendMessageToConnector({
-        type: Constants.SHARED_EVENT_TYPE.AFTER_CONVERSATION_WORK_ENDED,
+        type: Constants.VOICE_EVENT_TYPE.WRAP_UP_ENDED,
         acwInfo: {
             agentWorkId: acwAgentWorkField.value,
             workItemId: acwWorkItemField.value


### PR DESCRIPTION
A vendor has implemented the endACW() function based on the byo-demo-connector example. The example is wrong and does not follow the official [After Conversation Work](https://developer.salesforce.com/docs/atlas.en-us.voice_pt_developer_guide.meta/voice_pt_developer_guide/voice_pt_after_conversation_work.htm) documentation. This PR fixes the issues listed by the customer by replacing the invalid parameters by valid parameter (callId)